### PR TITLE
修复： t模式下客户端模拟浏览器提交时候的参数模式识别

### DIFF
--- a/twip.php
+++ b/twip.php
@@ -219,8 +219,10 @@ class twip{
         else{
             $this->request_headers['Host'] = 'api.twitter.com';
         }
+
+        // Don't parse POST arguments as array if emulating a browser submit
         if(isset($this->request_headers['Content-Type']) && 
-                $this->request_headers['Content-Type'] == 'application/x-www-form-urlencoded' ){
+                strpos($this->request_headers['Content-Type'], 'application/x-www-form-urlencoded') !== NULL){
             $this->parameters = $this->get_parameters(false);
         }else{
             $this->parameters = $this->get_parameters(true);


### PR DESCRIPTION
已知修复twidere客户端的t模式支持。

api： BASE_URL/t/1.1
oauth：BASE_URL/t/oauth
