### PR TITLE
Escape leading '@' when POSTing as multipart/form-data

### DIFF
--- a/twip.php
+++ b/twip.php
@@ -189,7 +189,7 @@ class twip{
 
                 $header_authorization = $this->connection->getOAuthRequest($this->request_uri, $this->method, null)->to_header();
                 $this->forwarded_headers = array("Host: api.twitter.com", $header_authorization, "Expect:");
-                $this->parameters = $_POST;
+                $this->parameters = preg_replace('/^@/', "\0@", $_POST);
 
                 $media = $_FILES['media'];
                 $fn = is_array($media['tmp_name']) ? $media['tmp_name'][0] : $media['tmp_name'];
@@ -256,7 +256,7 @@ class twip{
         if(strpos($this->request_uri,'statuses/update_with_media') !== FALSE &&
             strpos(@$this->request_headers['Content-Type'], 'multipart/form-data') !== FALSE) {
 
-            $this->parameters = $_POST;
+            $this->parameters = preg_replace('/^@/', "\0@", $_POST);
             if(count($_FILES) > 0 && isset($_FILES['media'])) {
                 $media = $_FILES['media'];
                 $fn = is_array($media['tmp_name']) ? $media['tmp_name'][0] : $media['tmp_name'];


### PR DESCRIPTION
Would cause cURL to treat the field as a filename.
