### PR TITLE
add secure rules and document for web servers

### DIFF
--- a/include/.htaccess
+++ b/include/.htaccess
@@ -1,0 +1,2 @@
+Order deny,allow
+Deny from all

--- a/oauth/.htaccess
+++ b/oauth/.htaccess
@@ -1,0 +1,2 @@
+Order deny,allow
+Deny from all

--- a/rewrite_rules.txt
+++ b/rewrite_rules.txt
@@ -1,27 +1,67 @@
-For NGINX users, please use the following rules:
-if (!-e $request_filename){rewrite ^/(.*)$ /index.php last;}
-(Provided by @imsoff)
-For lightTPD users, please use the following rules:
-url.rewrite-if-not-file += ( "^/(.*)$" => "/index.php/$1" )
-(Provided by kk198)
+Rewrite Rules
+=============
 
-If your TWIP installation have a prefix of /twip/, then you should use
 
-^/twip/(.*)$ /twip/index.php
+Apache
+======
 
-instead of 
+    Just set `AllowOverride` in you Host, Apache will follow `.htaccess` rules provided in twip.
 
-^/(.*)$. /index.php
+Nginx(with php-fpm)
+===================
 
-Just a reminder, please specify the index-file to "index.php"
+    Example:
 
-lighTPD:
+    ---
+        server {
+            listen      443 ssl spdy;
+            server_name m.example.net; 
+            ssl on;
+            ssl_certificate /path/to/cert.crt;
+            ssl_certificate_key /path/to/privkey.pem;
+            ssl_prefer_server_ciphers   on;
+            client_max_body_size 8m;
+            gzip     on;
+            index    index.php;
 
-index-file.names   = ( "index.php", "index.html",
-                       "index.htm", "default.htm" )
+            root     /srv/http/twitter;
+            location /twip/oauth { deny all; }
+            location /twip/ { try_files $uri /twip/index.php; }
+            location ~ \.php$ {
+                try_files $uri =404;
+                include fastcgi_params;
+                fastcgi_pass unix:/var/run/php-fpm/php-cgi.socket;
+            }
+        }
+    ---
 
-nginx:
+    Note:
 
-location / { # it can be /twip as well
-  index index.php;
-}
+    In the example, twip source is located at: `/srv/http/twitter/twip`, and twip is working at `https://m.example.net/twip`.
+    If you want to change to some other directory, change `root` / `location /twip/oauth` / `location /twip/`
+    Remember to protect `/twip/oauth/` from leaking info when you're adjusting rules.
+
+
+lightTPD
+========
+    (Sorry I'm not familar with lightTPD, can't provide a working example here, text below was provided by someone other. If you want to help other lightTPD users, fire an issue at github with a full example.)
+
+
+    ---
+    For lightTPD users, please use the following rules:
+    url.rewrite-if-not-file += ( "^/(.*)$" => "/index.php/$1" )
+    (Provided by kk198)
+
+
+    Just a reminder, please specify the index-file to "index.php"
+
+    ^/twip/(.*)$ /twip/index.php
+
+    instead of 
+
+    ^/(.*)$. /index.php
+
+    index-file.names   = ( "index.php", "index.html",
+                           "index.htm", "default.htm" )
+
+    ---


### PR DESCRIPTION
An poorly configured twip instance may cause user authentication being leaked.
Users shoud be alerted with this.
